### PR TITLE
Optimized the present dockerfile for dev-container

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -3,23 +3,21 @@
 # Licensed under the MIT License. See https://go.microsoft.com/fwlink/?linkid=2090316 for license information.
 #-------------------------------------------------------------------------------------------------------------
 
-FROM debian:9
+FROM debian:9-slim
 
 # Configure apt
 ENV DEBIAN_FRONTEND=noninteractive
 RUN apt-get update \
-    && apt-get -y install --no-install-recommends apt-utils 2>&1
-
+    && apt-get -y install --no-install-recommends apt-utils 2>&1 && \
 # Install git, process tools, lsb-release (common in install instructions for CLIs)
-RUN apt-get -y install git procps lsb-release
-
+    apt-get -y install git procps lsb-release && \
 # Install C++ tools
-RUN apt-get -y install build-essential cmake cppcheck valgrind
-
+    apt-get -y install build-essential cmake cppcheck valgrind && \
 # Clean up
-RUN apt-get autoremove -y \
+    apt-get autoremove -y \
     && apt-get clean -y \
     && rm -rf /var/lib/apt/lists/*
+
 ENV DEBIAN_FRONTEND=dialog
 
 # Set the default shell to bash instead of sh


### PR DESCRIPTION
### Explanation to changes implemented
* Shifted the base image to `debian:9-slim` from `debian:9`. 
*Reason:* This is done to reduce the size of the docker image and to reduce the initial docker image build time by `Visual Studio Code`. 

* Ran multiple consecutive `RUN` commands in a single intermediate container 
*Reason:* In order to further optimize Dockerfile by reducing the number of Docker layers and for faster builds and lighter containers.


### Results:
* Faster docker builds by `Visual Studio Code` so less initial waiting time.
* Lighter docker dev-container 
* docker image size reduced to `~660 MB`

Tested locally through `vs code`